### PR TITLE
Add reimbursement guidelines in new reimbursement.md

### DIFF
--- a/docs/Resources/reimbursement.md
+++ b/docs/Resources/reimbursement.md
@@ -1,0 +1,24 @@
+# Reimbursements
+
+Please keep all receipts for any expense you'd like reimbursed. Itemized receipts are usually required, and a reimbursement can't be finalized without the appropriate documentation.
+
+Reimbursements are submitted through [Workday](https://www.myworkday.com/yale/d/home.html). Before yours can be processed, you'll need to add Liz (Elizabeth Wallack) as your delegate for the Create Expense Report process:
+
+1. Open Workday and search for "Manage Delegations".
+2. In the delegation setup, add Elizabeth Wallack as your delegate.
+3. Under the business processes she can start on your behalf, select **Create Expense Report**.
+
+Once Liz has been added as your delegate, email her at [elizabeth.wallack@yale.edu](mailto:elizabeth.wallack@yale.edu) with:
+
+- The business purpose for the reimbursement
+- The COA obtained from Dan
+- Copies of all relevant receipts
+
+If the reimbursement is for a conference poster or abstract, please also include:
+
+- The talk or poster title
+- The conference location
+- The conference dates
+- The relevant credit card statement
+
+Finally, after Liz creates the expense report in Workday, you'll need to review and approve it there so the reimbursement can be submitted and finalized.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
     - Lab Logistics:
       - Travel: Resources/travel.md
       - Purchases: Resources/purchases.md
+      - Reimbursements: Resources/reimbursement.md
       - Booking Rooms: Resources/booking.md
       - Mailing Lists: Resources/mailing_lists.md
       - Mental Health: Resources/mental_health.md


### PR DESCRIPTION
This pull request adds new documentation on the reimbursement process and updates the site navigation to include this information. The main focus is to provide clear instructions for lab members on how to submit reimbursement requests.

Documentation updates:

* Added a new `docs/Resources/reimbursement.md` file with step-by-step instructions for submitting reimbursements, including required documentation, delegate setup in Workday, and special requirements for conference-related expenses.

Navigation updates:

* Updated `mkdocs.yml` to add "Reimbursements" to the Lab Logistics section of the navigation, linking to the new reimbursement documentation.